### PR TITLE
Support for importing an existing package.json with arbitrary fields …

### DIFF
--- a/gxutil/pm.go
+++ b/gxutil/pm.go
@@ -184,11 +184,6 @@ func writePkgHook(dir, hook string) error {
 
 func (pm *PM) InitPkg(dir, name, lang string, setup func(*Package)) error {
 	// check for existing packagefile
-	p := filepath.Join(dir, PkgFileName)
-	_, err := os.Stat(p)
-	if err == nil {
-		return errors.New("package file already exists in working dir")
-	}
 
 	username := pm.cfg.User.Name
 	if username == "" {
@@ -208,6 +203,11 @@ func (pm *PM) InitPkg(dir, name, lang string, setup func(*Package)) error {
 			GxVersion: GxVersion,
 		},
 	}
+	p := filepath.Join(dir, PkgFileName)
+	_, err := os.Stat(p)
+	if err == nil {
+		LoadPackageFile(pkg, PkgFileName)
+	}
 
 	if setup != nil {
 		setup(pkg)
@@ -216,7 +216,7 @@ func (pm *PM) InitPkg(dir, name, lang string, setup func(*Package)) error {
 	// check if the user has a tool installed for the selected language
 	CheckForHelperTools(lang)
 
-	err = SavePackageFile(pkg, p)
+	err = SavePackageFile(pkg, p, pkg.NonGxFields)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ var ImportCommand = cli.Command{
 		}
 
 		pkg.Dependencies = append(pkg.Dependencies, ndep)
-		err = gx.SavePackageFile(pkg, PkgFileName)
+		err = gx.SavePackageFile(pkg, PkgFileName, pkg.NonGxFields)
 		if err != nil {
 			log.Fatal("writing pkgfile: %s", err)
 		}
@@ -283,7 +283,7 @@ var InstallCommand = cli.Command{
 		}
 
 		if save {
-			err := gx.SavePackageFile(pkg, PkgFileName)
+			err := gx.SavePackageFile(pkg, PkgFileName, pkg.NonGxFields)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -344,7 +344,12 @@ var InitCommand = cli.Command{
 
 		log.Log("initializing package %s...", pkgname)
 		err := pm.InitPkg(cwd, pkgname, lang, func(p *gx.Package) {
-			p.Issues = promptUser("where should users go to report issues?")
+			if p.Issues == nil {
+				url := promptUser("where should users go to report issues?")
+				p.Issues = &gx.Issues{
+					Url: url,
+				}
+			}
 		})
 
 		if err != nil {
@@ -444,7 +449,7 @@ continue?`, olddep.Name, olddep.Hash, npkg.Name, target)
 		olddep.Hash = target
 		olddep.Version = npkg.Version
 
-		err = gx.SavePackageFile(pkg, PkgFileName)
+		err = gx.SavePackageFile(pkg, PkgFileName, pkg.NonGxFields)
 		if err != nil {
 			log.Fatal("writing package file: %s", err)
 		}
@@ -513,7 +518,7 @@ EXAMPLE:
 		}
 
 		defer func() {
-			err := gx.SavePackageFile(pkg, PkgFileName)
+			err := gx.SavePackageFile(pkg, PkgFileName, pkg.NonGxFields)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/update.go
+++ b/update.go
@@ -88,7 +88,7 @@ func fetchAndUpdate(tofetch string, updates map[string]string, checked map[strin
 	}
 
 	if changed {
-		err := gx.SavePackageFile(pkg, filepath.Join(dir, pkg.Name, gx.PkgFileName))
+		err := gx.SavePackageFile(pkg, filepath.Join(dir, pkg.Name, gx.PkgFileName), pkg.NonGxFields)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
…during `gx init`.

I'm principally a JS guy, which will probably be obvious :) but this is an attempt at this.  

I've modified a few of the `PackageBase` properties to correspond 1-1 with `npm` fields where it made sense to overlap -- `keywords`, `bugs`, `repository`.

I added a property `PackageBase.NonGxFields` which is just a `map[string]interface{}` of any pre-existing `package.json`.

The problem I ran into, that I couldn't solve in the way I would want to in Go is, treating the `Package` struct created in a `gx-*` tool as `{gxutils/pkgfile.go}.Package`.  I guess there's no way to 'typeassert' in a really generic way in Go?  Anway, I hackily solved the problem by having the `gx-*` tool pass the ref to a `map[string]interface{}` of the original `package.json` to gx.SavePackageFile as a third arg.  

I made some very minor modification to the `gx-js` tool here to support that change: https://github.com/sterpe/gx-js/pull/1

There's probably some way better Go-way to do it.


