### PR TITLE
Fix windows path slash bug

### DIFF
--- a/gxutil/publish.go
+++ b/gxutil/publish.go
@@ -44,6 +44,9 @@ func (pm *PM) PublishPackage(dir string, pkg *PackageBase) (string, error) {
 			rel = rel[1:]
 		}
 
+		// make relative path cross platform safe
+		rel = filepath.ToSlash(rel)
+
 		// respect gitignore
 		if gitig != nil && gitig.MatchesPath(rel) {
 			return nil


### PR DESCRIPTION
Not sure if this is the best approach to cross platform compatibility in Go, but this patch fixes my issue with `gx publish` under windows.

Fixes https://github.com/whyrusleeping/gx/issues/39