### PR TITLE
main: add `gx deps find <dep>`

### DIFF
--- a/main.go
+++ b/main.go
@@ -725,6 +725,7 @@ var DepsCommand = cli.Command{
 	},
 	Subcommands: []cli.Command{
 		depBundleCommand,
+		depFindCommand,
 	},
 	Action: func(c *cli.Context) {
 		rec := c.Bool("r")
@@ -788,6 +789,32 @@ var DepsCommand = cli.Command{
 		} else {
 			io.Copy(os.Stdout, buf)
 		}
+	},
+}
+
+var depFindCommand = cli.Command{
+	Name:  "find",
+	Usage: "print hash of a given dependency",
+	Action: func(c *cli.Context) {
+
+		if len(c.Args()) != 1 {
+			log.Fatal("must be passed exactly one argument")
+		}
+
+		pkg, err := LoadPackageFile(PkgFileName)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		dep := c.Args()[0]
+
+		for _, d := range pkg.Dependencies {
+			if d.Name == dep {
+				fmt.Println(d.Hash)
+				return
+			}
+		}
+		log.Fatal("no dependency named '%s' found", dep)
 	},
 }
 


### PR DESCRIPTION
In https://github.com/ipfs/go-ipfs/pull/2545 @whyrusleeping wrote "i think the best way to do that right now is to do something like gx deps | grep iptb | awk '{ print $2 }'. I need to add something to gx deps to make that query easier"

This PR add the `find` subcommand to `gx deps` so that one can do `gx deps find iptb` instead of the above command.