### PR TITLE
Do not escape HTML in package.json output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: go
 
 go:
-    - 1.5.3
+    - 1.7
 
 env:
     - TEST_VERBOSE=1

--- a/gxutil/pkgfile.go
+++ b/gxutil/pkgfile.go
@@ -84,7 +84,9 @@ func SavePackageFile(pkg interface{}, fname string) error {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := json.NewEncoder(buf).Encode(pkg); err != nil {
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(pkg); err != nil {
 		return err
 	}
 
@@ -103,11 +105,19 @@ func writeJson(i interface{}, fname string) error {
 	}
 	defer fi.Close()
 
-	out, err := json.MarshalIndent(i, "", "  ")
-	if err != nil {
+	buf := new(bytes.Buffer)
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(i); err != nil {
 		return err
 	}
-	_, err = fi.Write(out)
+
+	out := new(bytes.Buffer)
+	if json.Indent(out, buf.Bytes(), "", " ") != nil {
+		return err
+	}
+
+	_, err = fi.Write(out.Bytes())
 	fi.WriteString("\n")
 	return err
 }

--- a/tests/t0010-init.sh
+++ b/tests/t0010-init.sh
@@ -11,13 +11,17 @@ test_description="test package init"
 test_init_ipfs
 test_launch_ipfs_daemon
 
-pkg_hash="QmPKjGmE57YaeNePfQivpaZJkpiVJtacJTi7W4TDK2GMrw"
+pkg_hash="QmQnaq1hCywKUfEMMNdA6RmnBAoTrDTZd8hKVeAsUS25qx"
 
 test_expect_success "setup test package" '
 	which gx &&
 	mkdir mypkg &&
-	echo "{\"User\":{\"Name\":\"gxguy\"}}" > mypkg/.gxrc &&
+	echo "{\"User\":{\"Name\":\"gxguy <gxguy@gx.io>\"}}" > mypkg/.gxrc &&
 	(cd mypkg && gx init --lang=none)
+'
+
+test_expect_success "author string intact" '
+	grep "gxguy <gxguy@gx.io>" mypkg/package.json
 '
 
 test_expect_success "package.json has right values" '


### PR DESCRIPTION
The Go JSON encoder escapes characters such as < and > in its output by default, resulting in "author" strings like `foo <foo@bar.io>` being read from package.json correctly, but on any writes gx does to the file it is written as `foo \u003cfoo@bar.io\u003e`. `jq` seems to unescape these when reading, which kept the issue from surfacing in sharness tests.

This was done as a safety precaution to keep HTML from being embedded in JSON payloads, but this does not seem to apply in the case of a package.json file.

This patch modifies the package.json writing logic to not escape HTML.