### PR TITLE
Bump version to 0.9.1.

### DIFF
--- a/gxutil/pm.go
+++ b/gxutil/pm.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/whyrusleeping/stump"
 )
 
-const GxVersion = "0.9.0"
+const GxVersion = "0.9.1"
 
 const PkgFileName = "package.json"
 

--- a/package.json
+++ b/package.json
@@ -3,5 +3,5 @@
   "language": "go",
   "license": "",
   "name": "gx",
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/tests/t0010-init.sh
+++ b/tests/t0010-init.sh
@@ -11,7 +11,7 @@ test_description="test package init"
 test_init_ipfs
 test_launch_ipfs_daemon
 
-pkg_hash="QmQnaq1hCywKUfEMMNdA6RmnBAoTrDTZd8hKVeAsUS25qx"
+pkg_hash="QmTc3CuMBHooVrGmQ1CnrDLYMhDdXqkBSTNv43SHtGhDr7"
 
 test_expect_success "setup test package" '
 	which gx &&


### PR DESCRIPTION
This is to include https://github.com/whyrusleeping/gx/pull/94 as a patch-level (bugfix) version bump. I don't think I can push a tag in a PR, so that will have to be done on your end.