### PR TITLE
Makefile: add check for go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
-all:
+# Minimum version numbers for software required to build gx
+GX_MIN_GO_VERSION = 1.7
+
+# The default target of this Makefile is...
+all::
+
+go_check:
+	@bin/check_go_version $(GX_MIN_GO_VERSION)
+
+all:: go_check
 	go build
 
-install:
+install: go_check
 	go install
 
 test:
 	cd tests && make
 
-deps:
+deps: go_check
 	go get .

--- a/bin/check_go_version
+++ b/bin/check_go_version
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Check that the go version is at least equal to a minimum version
+# number.
+#
+# Call it for example like this:
+#
+#   $ check_go_version "1.5.2"
+#
+
+USAGE="$0 GO_MIN_VERSION"
+
+die() {
+    printf >&2 "fatal: %s\n" "$@"
+    exit 1
+}
+
+# Get arguments
+
+test "$#" -eq "1" || die "This program must be passed exactly 1 arguments" "Usage: $USAGE"
+
+GO_MIN_VERSION="$1"
+
+UPGRADE_MSG="Please take a look at https://golang.org/doc/install to install or upgrade go."
+
+# Get path to the directory containing this file
+# If $0 has no slashes, uses "./"
+PREFIX=$(expr "$0" : "\(.*\/\)") || PREFIX='./'
+# Include the 'check_at_least_version' function
+. ${PREFIX}check_version
+
+# Check that the go binary exist and is in the path
+
+type go >/dev/null 2>&1 || die_upgrade "go is not installed or not in the PATH!"
+
+# Check the go binary version
+
+VERS_STR=$(go version 2>&1) || die "'go version' failed with output: $VERS_STR"
+
+GO_CUR_VERSION=$(expr "$VERS_STR" : ".*go version go\([^ ]*\) .*") || die "Invalid 'go version' output: $VERS_STR"
+
+check_at_least_version "$GO_MIN_VERSION" "$GO_CUR_VERSION" "go"

--- a/bin/check_version
+++ b/bin/check_version
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+if test "x$UPGRADE_MSG" = "x"; then
+    printf >&2 "fatal: Please set '"'$UPGRADE_MSG'"' before sourcing this script\n"
+    exit 1
+fi
+
+die_upgrade() {
+    printf >&2 "fatal: %s\n" "$@"
+    printf >&2 "=> %s\n" "$UPGRADE_MSG"
+    exit 1
+}
+
+major_number() {
+    vers="$1"
+
+    # Hack around 'expr' exiting with code 1 when it outputs 0
+    case "$vers" in
+        0) echo "0" ;;
+        0.*) echo "0" ;;
+        *) expr "$vers" : "\([^.]*\).*" || return 1
+    esac
+}
+
+check_at_least_version() {
+    MIN_VERS="$1"
+    CUR_VERS="$2"
+    PROG_NAME="$3"
+
+    # Get major, minor and fix numbers for each version
+    MIN_MAJ=$(major_number "$MIN_VERS") || die "No major version number in '$MIN_VERS' for '$PROG_NAME'"
+    CUR_MAJ=$(major_number "$CUR_VERS") || die "No major version number in '$CUR_VERS' for '$PROG_NAME'"
+
+    # We expect a version to be of form X.X.X
+    # if the second dot doesn't match, we consider it a prerelease
+
+    if MIN_MIN=$(expr "$MIN_VERS" : "[^.]*\.\([0-9]\+\)"); then
+        # this captured digit is neccessary, since expr returns code 1 if the output is empty
+        if expr "$MIN_VERS" : "[^.]*\.[0-9]*\([0-9]\.\|[0-9]\$\)" >/dev/null; then
+            MIN_PRERELEASE="0"
+        else
+            MIN_PRERELEASE="1"
+        fi
+        MIN_FIX=$(expr "$MIN_VERS" : "[^.]*\.[0-9]\+[^0-9]\+\([0-9]\+\)") || MIN_FIX="0"
+    else
+        MIN_MIN="0"
+        MIN_PRERELEASE="0"
+        MIN_FIX="0"
+    fi
+    if CUR_MIN=$(expr "$CUR_VERS" : "[^.]*\.\([0-9]\+\)"); then
+        # this captured digit is neccessary, since expr returns code 1 if the output is empty
+        if expr "$CUR_VERS" : "[^.]*\.[0-9]*\([0-9]\.\|[0-9]\$\)" >/dev/null; then
+            CUR_PRERELEASE="0"
+        else
+            CUR_PRERELEASE="1"
+        fi
+        CUR_FIX=$(expr "$CUR_VERS" : "[^.]*\.[0-9]\+[^0-9]\+\([0-9]\+\)") || CUR_FIX="0"
+    else
+        CUR_MIN="0"
+        CUR_PRERELEASE="0"
+        CUR_FIX="0"
+    fi
+
+    # Compare versions
+    VERS_LEAST="$PROG_NAME version '$CUR_VERS' should be at least '$MIN_VERS'"
+    test "$CUR_MAJ" -lt "$MIN_MAJ" && die_upgrade "$VERS_LEAST"
+    test "$CUR_MAJ" -gt "$MIN_MAJ" || {
+        test "$CUR_MIN" -lt "$MIN_MIN" && die_upgrade "$VERS_LEAST"
+        test "$CUR_MIN" -gt "$MIN_MIN" || {
+            test "$CUR_PRERELEASE" -gt "$MIN_PRERELEASE" && die_upgrade "$VERS_LEAST"
+            test "$CUR_PRERELEASE" -lt "$MIN_PRERELEASE" || {
+                test "$CUR_FIX" -lt "$MIN_FIX" && die_upgrade "$VERS_LEAST"
+                true
+            }
+        }
+    }
+}


### PR DESCRIPTION
As gx now only works with go 1.7 or higher, let's check that
before building.

To perform this check, this adds the following shell scripts:

- bin/check_go_version
- bin/check_version

These scripts are copied from go-ipfs.