### PR TITLE
tests: ignore 'trash directory.*.sh/'

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+trash directory.*.sh/


### PR DESCRIPTION
When running tests like `./t0010-init.sh -v -i` in tests/, trash directories are left on purpose to make it easy to debug a failing test. Let's ignore these directories.