### PR TITLE
gx import: add example to CLI help.

### DIFF
--- a/main.go
+++ b/main.go
@@ -221,6 +221,11 @@ func writeLastPub(vers string, hash string) error {
 var ImportCommand = cli.Command{
 	Name:  "import",
 	Usage: "import a package as a dependency",
+	Description: `Download packages and add them as a dependency in package.json.
+
+EXAMPLE
+  > gx import QmUAQaWbKxGCUTuoQVvvicbQNZ9APF5pDGWyAZSe93AtKH
+`,
 	Flags: []cli.Flag{
 		cli.BoolTFlag{
 			Name:  "global",

--- a/main.go
+++ b/main.go
@@ -225,6 +225,10 @@ var ImportCommand = cli.Command{
 
 EXAMPLE
   > gx import QmUAQaWbKxGCUTuoQVvvicbQNZ9APF5pDGWyAZSe93AtKH
+  > gx import github.com/libp2p/go-libp2p
+
+    In the last example, Gx will check the ".gx/lastpubver"
+    file in the repository to find which hash to import.
 `,
 	Flags: []cli.Flag{
 		cli.BoolTFlag{


### PR DESCRIPTION
The first time I used import I had to lookup the gx readme to
figure out how to actully use it. It was not clear if it expects:
  * mHash
  * mHash/pkgname
  * ipfs/mHash
  * fs:/ipfs/mHash
  * etc.