### PR TITLE
Fix/windows subtool suffix

### DIFF
--- a/gxutil/pm.go
+++ b/gxutil/pm.go
@@ -24,9 +24,14 @@ const GxVersion = "0.12.1"
 const PkgFileName = "package.json"
 
 var installPathsCache map[string]string
+var binarySuffix string
 
 func init() {
 	installPathsCache = make(map[string]string)
+
+	if runtime.GOOS == "windows" {
+		binarySuffix = ".exe"
+	}
 }
 
 type PM struct {
@@ -669,20 +674,15 @@ func getSubtoolPath(env string) (string, error) {
 		return "", nil
 	}
 
-	var suffix string
-	if runtime.GOOS == "windows" {
-		suffix = ".exe"
-	}
-
-	binname := "gx-" + env + suffix
+	binname := "gx-" + env + binarySuffix
 	_, err := exec.LookPath(binname)
 	if err != nil {
 		if !strings.Contains(err.Error(), "file not found") {
 			return "", err
 		}
 
-		if strings.HasSuffix(os.Args[0], "/gx") {
-			nearBin := os.Args[0] + "-" + env + suffix
+		if calledWithPathSeparator() {
+			nearBin := strings.TrimSuffix(os.Args[0], binarySuffix) + "-" + env + binarySuffix
 			if _, err := os.Stat(nearBin); err != nil {
 				VLog("subtool_exec: No gx helper tool found for", env)
 				return "", nil
@@ -694,6 +694,25 @@ func getSubtoolPath(env string) (string, error) {
 	}
 
 	return binname, nil
+}
+
+func calledWithPathSeparator() bool {
+	trimmedArg := strings.TrimSuffix(os.Args[0], binarySuffix)
+	if trimmedArg == "gx" {
+		return false
+	}
+
+	if runtime.GOOS == "windows" {
+		if strings.HasSuffix(trimmedArg, (string(os.PathSeparator)+"gx")) || strings.HasSuffix(trimmedArg, "/gx") {
+			return true
+		}
+	} else {
+		if strings.HasSuffix(trimmedArg, (string(os.PathSeparator) + "gx")) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TryRunHook(hook, env string, req bool, args ...string) error {

--- a/gxutil/pm.go
+++ b/gxutil/pm.go
@@ -677,7 +677,11 @@ func getSubtoolPath(env string) (string, error) {
 	binname := "gx-" + env + binarySuffix
 	_, err := exec.LookPath(binname)
 	if err != nil {
-		if !strings.Contains(err.Error(), "file not found") {
+		if eErr, ok := err.(*exec.Error); ok {
+			if eErr.Err != exec.ErrNotFound {
+				return "", err
+			}
+		} else {
 			return "", err
 		}
 


### PR DESCRIPTION
https://github.com/whyrusleeping/gx/pull/150 does not fix issue https://github.com/whyrusleeping/gx/issues/153
This set does. An explanation on the ||, Windows will accept both `/` and its native separator, so we need to check for either.

ae64f8aabdc1751565054920e50ffcd4fa74b7b0 is not necessary but I feel like it's more correct since that string varies for each platform, if upstream changes it, we'll fail where we should succeed.

I don't know if there's a nicer way to handle this, criticism welcomed. 

Edit: hash changed
  