### PR TITLE
[WIP] get: try to remove destination directory before renaming download

### DIFF
--- a/gxutil/get.go
+++ b/gxutil/get.go
@@ -69,7 +69,11 @@ func (pm *PM) GetPackageTo(hash, out string) (*Package, error) {
 			stump.Log("retrying fetch %s after a second...", hash)
 			time.Sleep(time.Second)
 		} else {
-			if err := rname.Rename(outtemp, out); err != nil {
+			// Remove destination directory (if exists), else remain will fail.
+			if err := os.RemoveAll(out); err != nil {
+				return nil, err
+			}
+			if err = rname.Rename(outtemp, out); err != nil {
 				return nil, err
 			}
 			break


### PR DESCRIPTION
If the `package.json` file is missing from an installed package (not very likely) fetch will fail while trying to rename to an existing directory.

```
rm ~/go/src/gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2/pubsub/package.json
gx install
# ERROR: [97 / 97 ] parallel fetch: failed to fetch package: QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2: rename go/src/gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2.part go/src/gx/ipfs/QmdbxjQWogRCHRaxhhGnYdT1oQJzL9GdqSKzCdqWr85AP2: file exists
# ERROR: install deps: failed to fetch dependencies
```

Should a test be added?
