### PR TITLE
add a deps check command

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+
+	gx "github.com/whyrusleeping/gx/gxutil"
+)
+
+type pkgImport struct {
+	parents []string
+	version string
+}
+
+func check(pkg *gx.Package) (bool, error) {
+	var failed bool
+	// name -> hash -> path+version
+	packages := make(map[string]map[string]*pkgImport)
+
+	var traverse func(*gx.Package) error
+	traverse = func(pkg *gx.Package) error {
+		return pkg.ForEachDep(func(dep *gx.Dependency, dpkg *gx.Package) error {
+			pkgVersions, ok := packages[dpkg.Name]
+			if !ok {
+				pkgVersions = make(map[string]*pkgImport, 1)
+				packages[dpkg.Name] = pkgVersions
+			}
+			imp, ok := pkgVersions[dep.Hash]
+			if !ok {
+				pkgVersions[dep.Hash] = &pkgImport{
+					version: dpkg.Version,
+					parents: []string{pkg.Name},
+				}
+				return traverse(dpkg)
+			}
+			imp.parents = append(imp.parents, pkg.Name)
+			return nil
+		})
+	}
+	if err := traverse(pkg); err != nil {
+		return !failed, err
+	}
+	for name, pkgVersions := range packages {
+		switch len(pkgVersions) {
+		case 0:
+			panic("must have at least one package version")
+		case 1:
+			continue
+		}
+		failed = true
+
+		fmt.Printf("package %s imported as:\n", name)
+		for hash, imp := range pkgVersions {
+			fmt.Printf("  - %s %s\n", imp.version, hash)
+			for _, p := range imp.parents {
+				fmt.Printf("    - %s\n", p)
+			}
+		}
+	}
+	// Finally, check names and versions.
+	if err := pkg.ForEachDep(func(dep *gx.Dependency, dpkg *gx.Package) error {
+		if dep.Name != dpkg.Name {
+			failed = true
+			fmt.Printf(
+				"dependency %s references a package with name %s\n",
+				dep.Name,
+				dpkg.Name,
+			)
+		}
+		if dep.Version != dpkg.Version {
+			failed = true
+			fmt.Printf(
+				"dependency %s has version %s but the referenced package has version %s\n",
+				dep.Name,
+				dep.Version,
+				dpkg.Version,
+			)
+		}
+		return nil
+	}); err != nil {
+		return !failed, err
+	}
+	return !failed, nil
+}

--- a/main.go
+++ b/main.go
@@ -801,6 +801,27 @@ EXAMPLE:
 	},
 }
 
+var depCheckCommand = cli.Command{
+	Name:  "check",
+	Usage: "perform comprehensive sanity check and note any packaging issues",
+	Action: func(c *cli.Context) error {
+		pkg, err := LoadPackageFile(PkgFileName)
+		if err != nil {
+			return err
+		}
+		success, err := check(pkg)
+		if err != nil {
+			return err
+		}
+		if success {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
 var CleanCommand = cli.Command{
 	Name:  "clean",
 	Usage: "cleanup unused packages in vendor directory",
@@ -908,6 +929,7 @@ var DepsCommand = cli.Command{
 		depFindCommand,
 		depStatsCommand,
 		depDupesCommand,
+		depCheckCommand,
 	},
 	Action: func(c *cli.Context) error {
 		rec := c.Bool("r")


### PR DESCRIPTION
Checks for:

* Duplicate imports. Unlike `gx deps dupes`, the user won't need to follow up
  with a call to `gx deps --tree --highlight=...`.
* Package version mismatch (version in dep list doesn't match version in
  package).
* Package name mismatch (name in dep list doesn't match name in package).

It also exits with an exit status of 1 if something needs to be fixed so we can
run it from CI.

* [ ] Question: Currently, nothing in the output makes it clear that the package
  names listed under the duplicate import warnings are the *parents* that import
  that package. I could append "imported by" to the "$version $hash" line but
  that looks a bit funny...

Running this on go-ipfs right now prints out:

```
package protobuf imported as:
  - 0.0.0 QmT6n4mspWYEya864BhCUJEgyxiRfmiSY9ruQwTUNpRKaM
    - client_golang
    - client_model
    - common
    - golang_protobuf_extensions
    - go-ipfs
  - 0.0.0 QmXSs8cccbT4zDR95c1iRpYKDqVMzqeF1J6iZcavgE6eNw
    - badger
package go-detect-race imported as:
  - 0.0.0 QmQHGMVmrsgmqUG8ih3puNXUJneSpi13dkcZpzLKkskUkH
    - go-libp2p
  - 1.0.1 Qmf7HqcW7LtCi1W8y2bdx2eJpze74jkbKqpByxgXikdbLF
    - go-ipfs
package sys imported as:
  - 0.1.0 QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT
    - go-sockaddr
    - go-reuseport
    - go-ipfs-cmdkit
    - badger
    - go-ipfs
    - go4-lock
  - 0.1.0 QmTq8ag5pgTCqtGDtmpm1F5TPE2i1H8bcU6295WFKTc5ie
    - fuse
  - 0.0.1 QmTsTrxKNXu8sZLv7FP6p884CHoDbT9upKA1j4FkCy5V7T
    - fsnotify.v1
package go-log imported as:
  - 1.4.0 QmRb5jh8z2E8hMGN2tkvs1yHynUanqnZ3UeKwgN1i9P1F8
    - go-ipfs
    - go-libp2p-secio
    - go-libp2p-peer
    - go-libp2p-peerstore
    - go-libp2p
    - go-libp2p-transport
    - go-libp2p-loggables
    - go-tcp-transport
    - go-addr-util
    - go-testutil
    - go-libp2p-conn
    - go-libp2p-swarm
    - go-libp2p-nat
    - go-libp2p-netutil
    - go-libp2p-blankhost
    - go-libp2p-circuit
    - go-multiplex
    - go-ds-flatfs
    - go-metrics-prometheus
    - go-libp2p-kad-dht
    - go-libp2p-record
    - go-libp2p-kbucket
    - go-libp2p-floodsub
    - go-ipfs-cmds
    - go-libp2p-connmgr
    - go-ipfs-addr
    - go-ipfs-chunker
    - go-ipfs-blockstore
    - go-fs-lock
  - 1.2.0 QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52
    - go-reuseport
dependency go-ipfs-cmdkit has version 1.0.0-dev but the referenced package has version 1.0.0
```