### PR TITLE
sort the output of check (and check that versions parse)

### DIFF
--- a/check.go
+++ b/check.go
@@ -82,15 +82,10 @@ func check(pkg *gx.Package) (bool, error) {
 				jh := hashes[j]
 				iv := pkgVersions[ih].version
 				jv := pkgVersions[jh].version
-				switch iv.Compare(jv) {
-				case -1:
-					return true
-				case 1:
-					return false
-				case 0:
-					return ih < jh
+				if res := iv.Compare(jv); res != 0 {
+					return res < 0
 				}
-				panic("bad compare function")
+				return ih < jh
 			})
 
 			fmt.Printf("package %s imported as:\n", name)

--- a/check.go
+++ b/check.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"fmt"
+	"sort"
 
 	gx "github.com/whyrusleeping/gx/gxutil"
+
+	"github.com/blang/semver"
 )
 
 type pkgImport struct {
 	parents []string
-	version string
+	version semver.Version
 }
 
 func check(pkg *gx.Package) (bool, error) {
@@ -26,8 +29,18 @@ func check(pkg *gx.Package) (bool, error) {
 			}
 			imp, ok := pkgVersions[dep.Hash]
 			if !ok {
+				version, err := semver.Parse(dpkg.Version)
+				if dpkg.Version != "" && err != nil {
+					fmt.Printf(
+						"package %s (%s) has an invalid version '%s': %s\n",
+						dpkg.Name,
+						dep.Hash,
+						dpkg.Version,
+						err,
+					)
+				}
 				pkgVersions[dep.Hash] = &pkgImport{
-					version: dpkg.Version,
+					version: version,
 					parents: []string{pkg.Name},
 				}
 				return traverse(dpkg)
@@ -36,9 +49,12 @@ func check(pkg *gx.Package) (bool, error) {
 			return nil
 		})
 	}
+
 	if err := traverse(pkg); err != nil {
 		return !failed, err
 	}
+
+	var dupes []string
 	for name, pkgVersions := range packages {
 		switch len(pkgVersions) {
 		case 0:
@@ -46,16 +62,50 @@ func check(pkg *gx.Package) (bool, error) {
 		case 1:
 			continue
 		}
-		failed = true
+		dupes = append(dupes, name)
+	}
 
-		fmt.Printf("package %s imported as:\n", name)
-		for hash, imp := range pkgVersions {
-			fmt.Printf("  - %s %s\n", imp.version, hash)
-			for _, p := range imp.parents {
-				fmt.Printf("    - %s\n", p)
+	if len(dupes) > 0 {
+		failed = true
+		sort.Strings(dupes)
+
+		for _, name := range dupes {
+			pkgVersions := packages[name]
+
+			hashes := make([]string, 0, len(pkgVersions))
+			for h := range pkgVersions {
+				hashes = append(hashes, h)
+			}
+
+			sort.Slice(hashes, func(i, j int) bool {
+				ih := hashes[i]
+				jh := hashes[j]
+				iv := pkgVersions[ih].version
+				jv := pkgVersions[jh].version
+				switch iv.Compare(jv) {
+				case -1:
+					return true
+				case 1:
+					return false
+				case 0:
+					return ih < jh
+				}
+				panic("bad compare function")
+			})
+
+			fmt.Printf("package %s imported as:\n", name)
+			for _, hash := range hashes {
+				imp := pkgVersions[hash]
+
+				fmt.Printf("  - %s %s\n", imp.version, hash)
+				sort.Strings(imp.parents)
+				for _, p := range imp.parents {
+					fmt.Printf("    - %s\n", p)
+				}
 			}
 		}
 	}
+
 	// Finally, check names and versions.
 	if err := pkg.ForEachDep(func(dep *gx.Dependency, dpkg *gx.Package) error {
 		if dep.Name != dpkg.Name {


### PR DESCRIPTION
* Sort the output of deps check (easier to read at a glance):
  * Sort duplicate dependencies by ascending version.
  * Sort packages by name.

Also, warn if a version number doesn't parse with semver.