### PR TITLE
don't ignore vendored code by default

### DIFF
--- a/gxutil/publish.go
+++ b/gxutil/publish.go
@@ -84,11 +84,6 @@ func (pm *PM) PublishPackage(dir string, pkg *PackageBase) (string, error) {
 			return nil
 		}
 
-		// dont publish vendored code
-		if strings.HasPrefix(rel, "vendor") {
-			return nil
-		}
-
 		// dont publish gx repo files
 		if strings.HasPrefix(rel, ".gx/") || strings.HasSuffix(rel, ".gxrc") {
 			return nil


### PR DESCRIPTION
The user should either:

1. Add it to the .gxignore file if they want to support both gx and vendoring.
2. Delete it from the repo when gxifying it.

fixes #185

Thoughts @whyrusleeping? I'm pretty sure this won't break any of our existing
uses of gx and this is a more language independent solution than the current one.