### PR TITLE
Bump GxVersion to 0.14.2

### DIFF
--- a/gxutil/pm.go
+++ b/gxutil/pm.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/whyrusleeping/stump"
 )
 
-const GxVersion = "0.14.0"
+const GxVersion = "0.14.2"
 
 const PkgFileName = "package.json"
 const LckFileName = "gx-lock.json"


### PR DESCRIPTION
Bump GxVersion to 0.14.2
to avoid a 0.14.1 version claiming to be 0.14.0
in output of `gx -v`